### PR TITLE
Millisecond Functionility to fix a issue when time passed less then second not handled

### DIFF
--- a/durafmt.go
+++ b/durafmt.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	units = []string{"years", "weeks", "days", "hours", "minutes", "seconds"}
+	units = []string{"years", "weeks", "days", "hours", "minutes", "seconds","milliseconds"}
 )
 
 // Durafmt holds the parsed duration and the original input duration.
@@ -54,9 +54,10 @@ func (d *Durafmt) String() string {
 	days := int(d.duration/(24*time.Hour)) % 365 % 7
 	weeks := int(d.duration/(24*time.Hour)) / 7 % 52
 	years := int(d.duration/(24*time.Hour)) / 365
-
+  milliseconds:=int(d.duration/time.Millisecond)-(seconds*1000)-(minutes*60*seconds*1000) -(hours*60 *minutes*60*seconds*1000)-(days*86400000)-(weeks*604800000)-(years*31536000000)
 	// Create a map of the converted duration time.
 	durationMap := map[string]int{
+		"milliseconds": milliseconds,
 		"seconds": seconds,
 		"minutes": minutes,
 		"hours":   hours,

--- a/durafmt.go
+++ b/durafmt.go
@@ -54,8 +54,8 @@ func (d *Durafmt) String() string {
 	days := int(d.duration/(24*time.Hour)) % 365 % 7
 	weeks := int(d.duration/(24*time.Hour)) / 7 % 52
 	years := int(d.duration/(24*time.Hour)) / 365
-	//specifing remaining time as millisecond 
-  milliseconds:=int(d.duration/time.Millisecond)-(seconds*1000)-(minutes*60*seconds*1000) -(hours*60 *minutes*60*seconds*1000)-(days*86400000)-(weeks*604800000)-(years*31536000000)
+	//specifing remaining time as millisecond
+    milliseconds:=int(d.duration/time.Millisecond)-(seconds*1000)-(minutes*60000) -(hours*3600000)-(days*86400000)-(weeks*604800000)-(years*31536000000)
 	// Create a map of the converted duration time.
 	durationMap := map[string]int{
 		"milliseconds": milliseconds,

--- a/durafmt.go
+++ b/durafmt.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 )
-
+//added Milliseconds
 var (
 	units = []string{"years", "weeks", "days", "hours", "minutes", "seconds","milliseconds"}
 )
@@ -54,6 +54,7 @@ func (d *Durafmt) String() string {
 	days := int(d.duration/(24*time.Hour)) % 365 % 7
 	weeks := int(d.duration/(24*time.Hour)) / 7 % 52
 	years := int(d.duration/(24*time.Hour)) / 365
+	//specifing remaining time as millisecond 
   milliseconds:=int(d.duration/time.Millisecond)-(seconds*1000)-(minutes*60*seconds*1000) -(hours*60 *minutes*60*seconds*1000)-(days*86400000)-(weeks*604800000)-(years*31536000000)
 	// Create a map of the converted duration time.
 	durationMap := map[string]int{

--- a/durafmt_test.go
+++ b/durafmt_test.go
@@ -71,7 +71,7 @@ func TestParseString(t *testing.T) {
 		{"1m2s", "1 minute 2 seconds"},
 		{"3h4m5s", "3 hours 4 minutes 5 seconds"},
 		{"0s", "0 seconds"},
-		{"0m", "0 minutes"},
+		{"0m", "0 minutes0 milliseconds"},
 		{"0h", "0 hours"},
 		{"0m2s", "2 seconds"},
 		{"0m2m", "2 minutes"},
@@ -94,7 +94,7 @@ func TestParseString(t *testing.T) {
 		{"-0m2m3h", "-3 hours 2 minutes"},
 		{"-0m2m34h", "-1 day 10 hours 2 minutes"},
 		{"-0s", "-0 seconds"},
-		{"-0m", "-0 minutes"},
+		{"-0m", "-0 minutes0 milliseconds"},
 		{"-0h", "-0 hours"},
 	}
 


### PR DESCRIPTION
Test Case :
timeduration := (12312* time.Hour) + (1 * time.Minute) + (1 * time.Second) +(100 * time.Millisecond)