### PR TITLE
Add LimitToUnit() method to limit conversion until this unit.

### DIFF
--- a/durafmt_test.go
+++ b/durafmt_test.go
@@ -15,6 +15,11 @@ var (
 		test     time.Duration
 		expected string
 	}
+	testTimesWithLimitUnit []struct {
+		test     time.Duration
+		limitUnit string
+		expected string
+	}
 	testTimesWithLimit []struct {
 		test     time.Duration
 		limitN   int
@@ -72,6 +77,30 @@ func TestParse(t *testing.T) {
 
 	for _, table := range testTimes {
 		result := Parse(table.test).String()
+		if result != table.expected {
+			t.Errorf("Parse(%q).String() = %q. got %q, expected %q",
+				table.test, result, result, table.expected)
+		}
+	}
+}
+
+func TestParseWithLimitToUnit(t *testing.T) {
+	testTimesWithLimitUnit = []struct {
+		test     time.Duration
+		limitUnit string
+		expected string
+	}{
+		{87593183 * time.Second, "seconds", "87593183 seconds"},
+		{87593183 * time.Second, "minutes", "1459886 minutes 23 seconds"},
+		{87593183 * time.Second, "hours", "24331 hours 26 minutes 23 seconds"},
+		{87593183 * time.Second, "days", "1013 days 19 hours 26 minutes 23 seconds"},
+		{87593183 * time.Second, "weeks", "144 weeks 5 days 19 hours 26 minutes 23 seconds"},
+		{87593183 * time.Second, "years", "2 years 40 weeks 3 days 19 hours 26 minutes 23 seconds"},
+		{87593183 * time.Second, "", "2 years 40 weeks 3 days 19 hours 26 minutes 23 seconds"},
+	}
+
+	for _, table := range testTimesWithLimitUnit {
+		result := Parse(table.test).LimitToUnit(table.limitUnit).String()
 		if result != table.expected {
 			t.Errorf("Parse(%q).String() = %q. got %q, expected %q",
 				table.test, result, result, table.expected)

--- a/example_test.go
+++ b/example_test.go
@@ -25,6 +25,16 @@ func ExampleDurafmt_LimitFirstN() {
 	// duration.String() // String representation. "2 weeks 18 hours"
 }
 
+func ExampleDurafmt_LimitToUnit() {
+	duration, err := ParseString("354h22m3.24s")
+	if err != nil {
+		fmt.Println(err)
+	}
+	duration = duration.LimitToUnit("days")
+	fmt.Println(duration) // 14 days 18 hours 22 minutes 3 seconds
+	// duration.String() // String representation. "14 days 18 hours 22 minutes 3 seconds"
+}
+
 func ExampleParseString_sequence() {
 	for hours := 1.0; hours < 12.0; hours++ {
 		hour := fmt.Sprintf("%fh", math.Pow(2, hours))


### PR DESCRIPTION
Example : 
```
       duration, _ := ParseString("354h22m3.24s")
       fmt.Println(duration) // 2 weeks 18 hours 22 minutes 3 seconds

       duration, _ = ParseString("354h22m3.24s")
       duration = duration.LimitToUnit("days")
       fmt.Println(duration) // 14 days 18 hours 22 minutes 3 seconds
```