### PR TITLE
remove plural from international units

### DIFF
--- a/durafmt.go
+++ b/durafmt.go
@@ -295,14 +295,11 @@ func (d *Durafmt) InternationalString() string {
 		v := durationMap[u]
 		strval := strconv.FormatInt(v, 10)
 		switch {
-		// add to the duration string if v > 1.
-		case v > 1:
+		// add to the duration string if v > 0.
+		case v > 0:
 			duration += strval + " " + u + " "
-		// remove the plural 's', if v is 1.
-		case v == 1:
-			duration += strval + " " + strings.TrimRight(u, "s") + " "
-		// omit any value with 0s or 0.
-		case d.duration.String() == "0" || d.duration.String() == "0s":
+		// omit any value with 0.
+		case d.duration.String() == "0":
 			pattern := fmt.Sprintf("^-?0%s$", unitsShort[i])
 			isMatch, err := regexp.MatchString(pattern, d.input)
 			if err != nil {

--- a/durafmt_test.go
+++ b/durafmt_test.go
@@ -421,6 +421,40 @@ func TestInvalidDuration(t *testing.T) {
 	}
 }
 
+// TestInternationalString for valid output when using international strings
+func TestInternationalString(t *testing.T) {
+	var testStrings = []struct {
+		test     *Durafmt
+		expected string
+	}{
+		{Parse(5 * time.Microsecond), "5 µs"},
+		{Parse(1001 * time.Microsecond), "1 ms 1 µs"},
+		{Parse(5 * time.Millisecond), "5 ms"},
+		{Parse(1001 * time.Millisecond), "1 s 1 ms"},
+		{Parse(1 * time.Second), "1 s"},
+		{Parse(5 * time.Second), "5 s"},
+		{Parse(65 * time.Second), "1 m 5 s"},
+		{Parse(1 * time.Minute), "1 m"},
+		{Parse(2 * time.Minute), "2 m"},
+		{Parse(65 * time.Minute), "1 h 5 m"},
+		{Parse(1 * time.Hour), "1 h"},
+		{Parse(2 * time.Hour), "2 h"},
+		{Parse(24 * time.Hour), "1 d" },
+		{Parse(25 * time.Hour), "1 d 1 h" },
+		{Parse(48 * time.Hour), "2 d" },
+		{Parse(168 * time.Hour), "1 w" },
+		{Parse(170 * time.Hour), "1 w 2 h" },
+		{Parse(336 * time.Hour), "2 w" },
+	}
+
+	for _, table := range testStrings {
+		actual := table.test.InternationalString()
+		if actual != table.expected {
+			t.Fatalf("actual duration %s does not match expected duration %s", actual, table.expected)
+		}
+	}
+}
+
 // Benchmarks
 
 func BenchmarkParse(b *testing.B) {


### PR DESCRIPTION
The InternationalString units need no plural, and stripping the trailing 's' would result in some unusual output:
1 ms 1 µs => 1 m 1 µ
1 s 1 ms => 1  1 m
etc
This change should fix that
